### PR TITLE
Chainlink for ERC4626

### DIFF
--- a/src/Chainlink4626Oracle.sol
+++ b/src/Chainlink4626Oracle.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.19;
 import {IOracle} from "../lib/morpho-blue/src/interfaces/IOracle.sol";
 
 import {AggregatorV3Interface, ChainlinkDataFeedLib} from "./libraries/ChainlinkDataFeedLib.sol";
-import {ERC4626Interface} from "./interfaces/ERC4626Interface.sol";
+import {IERC4626} from "./interfaces/IERC4626.sol";
 
 contract Chainlink4626Oracle is IOracle {
     using ChainlinkDataFeedLib for AggregatorV3Interface;
@@ -12,7 +12,7 @@ contract Chainlink4626Oracle is IOracle {
     /* CONSTANT */
 
     /// @notice Vault.
-    ERC4626Interface public immutable VAULT;
+    IERC4626 public immutable VAULT;
     /// @notice Vault decimals.
     uint256 public immutable VAULT_DECIMALS;
     /// @notice Base feed.
@@ -29,7 +29,7 @@ contract Chainlink4626Oracle is IOracle {
     /// @param quoteFeed Quote feed. Pass address zero if the price = 1.
     /// @param quoteTokenDecimals Quote token decimals.
     constructor(
-        ERC4626Interface vault,
+        IERC4626 vault,
         AggregatorV3Interface baseFeed,
         AggregatorV3Interface quoteFeed,
         uint256 baseTokenDecimals,

--- a/src/interfaces/IERC4626.sol
+++ b/src/interfaces/IERC4626.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
-interface ERC4626Interface {
+interface IERC4626 {
     function convertToAssets(uint256) external view returns (uint256);
     function decimals() external view returns (uint256);
 }

--- a/test/Chainlink4626OracleTest.sol
+++ b/test/Chainlink4626OracleTest.sol
@@ -11,7 +11,7 @@ AggregatorV3Interface constant daiEthFeed = AggregatorV3Interface(0x773616E4d11A
 // 18 decimals of precision
 AggregatorV3Interface constant usdcEthFeed = AggregatorV3Interface(0x986b5E1e1755e3C2440e960477f25201B0a8bbD4);
 
-ERC4626Interface constant sDaiVault = ERC4626Interface(0x83F20F44975D03b1b09e64809B757c47f942BEeA);
+IERC4626 constant sDaiVault = IERC4626(0x83F20F44975D03b1b09e64809B757c47f942BEeA);
 
 contract Chainlink4626OracleTest is Test {
     function setUp() public {


### PR DESCRIPTION
Handles the following cases:
- A'/C and B/C are feeds, and there is an exchange rate between A and A'. (typically A=sDAI and A'=DAI).

ONLY THE VAULT TESTS:
![Screenshot from 2023-10-10 11-23-02](https://github.com/morpho-labs/morpho-blue-oracles/assets/22668539/943ba066-2935-4a7d-b604-7d139b7e51ae)

WITHOUT THE VAULT TESTS:
![Screenshot from 2023-10-10 11-39-54](https://github.com/morpho-labs/morpho-blue-oracles/assets/22668539/52a5d564-e062-4cee-9ac8-9c74b9130292)
