### PR TITLE
Alternative oracle to avoid overflows

### DIFF
--- a/src/ChainlinkOracleAlt.sol
+++ b/src/ChainlinkOracleAlt.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.19;
+
+import {IOracle} from "../lib/morpho-blue/src/interfaces/IOracle.sol";
+
+import {AggregatorV3Interface, Quantity, ChainlinkDataFeedAltLib} from "./libraries/ChainlinkDataFeedAltLib.sol";
+import {IERC4626, VaultLib} from "./libraries/VaultLib.sol";
+import {ErrorsLib} from "./libraries/ErrorsLib.sol";
+
+/// @title ChainlinkOracleAlt
+/// @author Morpho Labs
+/// @custom:contact security@morpho.org
+/// @notice Morpho Blue oracle using Chainlink-compliant feeds.
+contract ChainlinkOracleAlt is IOracle {
+    using VaultLib for IERC4626;
+    using ChainlinkDataFeedAltLib for AggregatorV3Interface;
+
+    /* IMMUTABLES */
+
+    /// @notice Vault.
+    IERC4626 public immutable VAULT;
+    /// @notice First base feed.
+    AggregatorV3Interface public immutable BASE_FEED_1;
+    uint256 public immutable BASE_TOKEN_1_DECIMALS;
+    /// @notice Second base feed.
+    AggregatorV3Interface public immutable BASE_FEED_2;
+    uint256 public immutable BASE_TOKEN_2_DECIMALS;
+    /// @notice First quote feed.
+    AggregatorV3Interface public immutable QUOTE_FEED_1;
+    uint256 public immutable QUOTE_TOKEN_1_DECIMALS;
+    /// @notice Second quote feed.
+    AggregatorV3Interface public immutable QUOTE_FEED_2;
+    uint256 public immutable QUOTE_TOKEN_2_DECIMALS;
+    /// @notice Denominator token decimals
+    uint256 public immutable DENOMINATOR_TOKEN_DECIMALS;
+
+    /* CONSTRUCTOR */
+
+    constructor(
+        IERC4626 vault,
+        AggregatorV3Interface baseFeed1,
+        uint256 baseToken1Decimals,
+        AggregatorV3Interface baseFeed2,
+        uint256 baseToken2Decimals,
+        AggregatorV3Interface quoteFeed1,
+        uint256 quoteToken1Decimals,
+        AggregatorV3Interface quoteFeed2,
+        uint256 quoteToken2Decimals,
+        uint256 denominatorTokenDecimals
+    ) {
+        VAULT = vault;
+        BASE_FEED_1 = baseFeed1;
+        BASE_TOKEN_1_DECIMALS = baseToken1Decimals;
+        BASE_FEED_2 = baseFeed2;
+        BASE_TOKEN_2_DECIMALS = baseToken2Decimals;
+        QUOTE_FEED_1 = quoteFeed1;
+        QUOTE_TOKEN_1_DECIMALS = quoteToken1Decimals;
+        QUOTE_FEED_2 = quoteFeed2;
+        QUOTE_TOKEN_2_DECIMALS = quoteToken2Decimals;
+        DENOMINATOR_TOKEN_DECIMALS = denominatorTokenDecimals;
+    }
+
+    /* PRICE */
+
+    /// @inheritdoc IOracle
+    function price() external view returns (uint256) {
+        uint256 denominatorSample = 10 ** DENOMINATOR_TOKEN_DECIMALS;
+
+        Quantity memory base = Quantity(denominatorSample, DENOMINATOR_TOKEN_DECIMALS);
+        base = BASE_FEED_2.convert(base, BASE_TOKEN_2_DECIMALS);
+        base = BASE_FEED_1.convert(base, BASE_TOKEN_1_DECIMALS);
+        base.amount = address(VAULT) == address(0) ? base.amount : VAULT.convertToShares(base.amount);
+
+        Quantity memory quote = Quantity(denominatorSample, DENOMINATOR_TOKEN_DECIMALS);
+        quote = QUOTE_FEED_2.convert(quote, QUOTE_TOKEN_2_DECIMALS);
+        quote = QUOTE_FEED_1.convert(quote, QUOTE_TOKEN_1_DECIMALS);
+
+        return (10 ** 36 * quote.amount) / base.amount;
+    }
+}

--- a/src/interfaces/IERC4626.sol
+++ b/src/interfaces/IERC4626.sol
@@ -3,4 +3,5 @@ pragma solidity ^0.8.0;
 
 interface IERC4626 {
     function convertToAssets(uint256) external view returns (uint256);
+    function convertToShares(uint256) external view returns (uint256);
 }

--- a/src/libraries/ChainlinkDataFeedAltLib.sol
+++ b/src/libraries/ChainlinkDataFeedAltLib.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {AggregatorV3Interface} from "../interfaces/AggregatorV3Interface.sol";
+
+import {ErrorsLib} from "./ErrorsLib.sol";
+
+struct Quantity {
+    uint256 amount;
+    uint256 decimals;
+}
+
+/// @title ChainlinkDataFeedAltLib
+/// @author Morpho Labs
+/// @custom:contact security@morpho.org
+/// @notice Library exposing functions to interact with a Chainlink-compliant feed.
+library ChainlinkDataFeedAltLib {
+    /// @notice Assuming `feed` is pricing output wrt to input, this converts an input amount into an output amount.
+    function convert(AggregatorV3Interface feed, Quantity memory inputQuantity, uint256 outputDecimals)
+        internal
+        view
+        returns (Quantity memory outputQuantity)
+    {
+        if (address(feed) == address(0)) return inputQuantity;
+
+        (, int256 answer,,,) = feed.latestRoundData();
+        require(answer >= 0, ErrorsLib.NEGATIVE_ANSWER);
+
+        outputQuantity.decimals = outputDecimals;
+        outputQuantity.amount = (inputQuantity.amount * 10 ** (outputDecimals + feed.decimals()))
+            / (10 ** inputQuantity.decimals * uint256(answer));
+    }
+}


### PR DESCRIPTION
This PR implements the third proposition in https://github.com/morpho-labs/morpho-blue-oracles/issues/15#issuecomment-1784981181. The idea is to use a sample amount, and to only convert between amounts,  in order to avoid multiplication overflow.

Remarks:
1. the sample amount is chosen to be the full unit of the denominator token. If we have A/B & B/C as base feeds, and D/E & E/C as quote feeds, then we call C the denominator token. The sample amount is determined in the first line of the `price()` function, but could be set at deployment instead
2. there are many optimizations left to do: notably the computation of the exponential of decimals and caching `feed.decimals()` in the Chainlink library
3. the returned prices have been checked to have less than 0.1% error compared to the original oracle