### PR TITLE
Natspec issues

### DIFF
--- a/src/morpho-chainlink/MorphoChainlinkOracleV2.sol
+++ b/src/morpho-chainlink/MorphoChainlinkOracleV2.sol
@@ -50,9 +50,8 @@ contract MorphoChainlinkOracleV2 is IMorphoChainlinkOracleV2 {
     /* CONSTRUCTOR */
 
     /// @dev Here is the list of assumptions that guarantees the oracle behaves as expected:
-    /// - Feeds are either Chainlink-compliant or the address zero.
-    /// - Feeds have the same behavioral assumptions as Chainlink's.
     /// - The vaults, if set, are ERC4626-compliant.
+    /// - The feeds, if set, are Chainlink-interface-compliant.
     /// - Decimals passed as argument are correct.
     /// - The base vaults's sample shares quoted as assets and the base feed prices don't overflow when multiplied.
     /// - The quote vault's sample shares quoted as assets and the quote feed prices don't overflow when multiplied.

--- a/src/morpho-chainlink/MorphoChainlinkOracleV2.sol
+++ b/src/morpho-chainlink/MorphoChainlinkOracleV2.sol
@@ -52,12 +52,10 @@ contract MorphoChainlinkOracleV2 is IMorphoChainlinkOracleV2 {
     /// @dev Here is the list of assumptions that guarantees the oracle behaves as expected:
     /// - Feeds are either Chainlink-compliant or the address zero.
     /// - Feeds have the same behavioral assumptions as Chainlink's.
-    /// - Feeds are set in the correct order.
+    /// - The vaults, if set, are ERC4626-compliant.
     /// - Decimals passed as argument are correct.
-    /// - The vaults' sample shares quoted as assets and the base feed prices don't overflow when multiplied.
-    /// - The quote feed prices don't overflow when multiplied.
-    /// - Vaults are either ERC4626-compliant or the address zero.
-    /// @dev The base asset is the collateral token and the quote asset is the loan token.
+    /// - The base vaults's sample shares quoted as assets and the base feed prices don't overflow when multiplied.
+    /// - The quote vault's sample shares quoted as assets and the quote feed prices don't overflow when multiplied.
     /// @param baseVault Base vault. Pass address zero to omit this parameter.
     /// @param baseVaultConversionSample The sample amount of base vault shares used to convert to underlying.
     /// Pass 1 if the base asset is not a vault. Should be chosen such that converting `baseVaultConversionSample` to

--- a/src/morpho-chainlink/MorphoChainlinkOracleV2.sol
+++ b/src/morpho-chainlink/MorphoChainlinkOracleV2.sol
@@ -70,6 +70,7 @@ contract MorphoChainlinkOracleV2 is IMorphoChainlinkOracleV2 {
     /// @param quoteFeed1 First quote feed. Pass address zero if the price = 1.
     /// @param quoteFeed2 Second quote feed. Pass address zero if the price = 1.
     /// @param quoteTokenDecimals Quote token decimals.
+    /// @dev The base asset should be the collateral token and the quote asset the loan token.
     constructor(
         IERC4626 baseVault,
         uint256 baseVaultConversionSample,

--- a/src/morpho-chainlink/MorphoChainlinkOracleV2.sol
+++ b/src/morpho-chainlink/MorphoChainlinkOracleV2.sol
@@ -125,7 +125,7 @@ contract MorphoChainlinkOracleV2 is IMorphoChainlinkOracleV2 {
         // = 1e36 * (pB1 * 1e(-dB1) * pB2) / (pQ1 * 1e(-dQ1) * pQ2)
 
         // Let fpB1, fpB2, fpQ1, fpQ2 be the feed precision of the respective prices pB1, pB2, pQ1, pQ2.
-        // Chainlink feeds return pB1 * 1e(fpB1), pB2 * 1e(fpB2), pQ1 * 1e(fpQ1) and pQ2 * 1e(fpQ2).
+        // Chainlink-compliant feeds return pB1 * 1e(fpB1), pB2 * 1e(fpB2), pQ1 * 1e(fpQ1) and pQ2 * 1e(fpQ2).
 
         // Based on the implementation of `price()` below, the value of `SCALE_FACTOR` should thus satisfy:
         // (pB1 * 1e(fpB1)) * (pB2 * 1e(fpB2)) * SCALE_FACTOR / ((pQ1 * 1e(fpQ1)) * (pQ2 * 1e(fpQ2)))

--- a/src/morpho-chainlink/interfaces/IMorphoChainlinkOracleV2.sol
+++ b/src/morpho-chainlink/interfaces/IMorphoChainlinkOracleV2.sol
@@ -22,16 +22,16 @@ interface IMorphoChainlinkOracleV2 is IOracle {
     /// @notice Returns the quote vault conversion sample.
     function QUOTE_VAULT_CONVERSION_SAMPLE() external view returns (uint256);
 
-    /// @notice Returns the address of the first Chainlink base feed.
+    /// @notice Returns the address of the first base feed.
     function BASE_FEED_1() external view returns (AggregatorV3Interface);
 
-    /// @notice Returns the address of the second Chainlink base feed.
+    /// @notice Returns the address of the second base feed.
     function BASE_FEED_2() external view returns (AggregatorV3Interface);
 
-    /// @notice Returns the address of the first Chainlink quote feed.
+    /// @notice Returns the address of the first quote feed.
     function QUOTE_FEED_1() external view returns (AggregatorV3Interface);
 
-    /// @notice Returns the address of the second Chainlink quote feed.
+    /// @notice Returns the address of the second quote feed.
     function QUOTE_FEED_2() external view returns (AggregatorV3Interface);
 
     /// @notice Returns the price scale factor, calculated at contract creation.

--- a/src/morpho-chainlink/interfaces/IMorphoChainlinkOracleV2Factory.sol
+++ b/src/morpho-chainlink/interfaces/IMorphoChainlinkOracleV2Factory.sol
@@ -19,8 +19,6 @@ interface IMorphoChainlinkOracleV2Factory {
     function isMorphoChainlinkOracleV2(address target) external view returns (bool);
 
     /// @dev Here is the list of assumptions that guarantees the oracle behaves as expected:
-    /// - Feeds are either Chainlink-compliant or the address zero.
-    /// - Feeds have the same behavioral assumptions as Chainlink's.
     /// - The vaults, if set, are ERC4626-compliant.
     /// - The feeds, if set, are Chainlink-interface-compliant.
     /// - Decimals passed as argument are correct.

--- a/src/morpho-chainlink/interfaces/IMorphoChainlinkOracleV2Factory.sol
+++ b/src/morpho-chainlink/interfaces/IMorphoChainlinkOracleV2Factory.sol
@@ -21,11 +21,10 @@ interface IMorphoChainlinkOracleV2Factory {
     /// @dev Here is the list of assumptions that guarantees the oracle behaves as expected:
     /// - Feeds are either Chainlink-compliant or the address zero.
     /// - Feeds have the same behavioral assumptions as Chainlink's.
-    /// - Feeds are set in the correct order.
+    /// - The vaults, if set, are ERC4626-compliant.
     /// - Decimals passed as argument are correct.
-    /// - The vault's sample shares quoted as assets and the base feed prices don't overflow when multiplied.
-    /// - The quote feed prices don't overflow when multiplied.
-    /// - The vault, if set, is ERC4626-compliant.
+    /// - The base vaults's sample shares quoted as assets and the base feed prices don't overflow when multiplied.
+    /// - The quote vault's sample shares quoted as assets and the quote feed prices don't overflow when multiplied.
     /// @param baseVault Base vault. Pass address zero to omit this parameter.
     /// @param baseVaultConversionSample The sample amount of base vault shares used to convert to underlying.
     /// Pass 1 if the base asset is not a vault. Should be chosen such that converting `baseVaultConversionSample` to
@@ -40,7 +39,7 @@ interface IMorphoChainlinkOracleV2Factory {
     /// @param quoteFeed1 First quote feed. Pass address zero if the price = 1.
     /// @param quoteFeed2 Second quote feed. Pass address zero if the price = 1.
     /// @param quoteTokenDecimals Quote token decimals.
-    /// @param salt The salt to use for the MetaMorpho vault's CREATE2 address.
+    /// @param salt The salt to use for the CREATE2.
     function createMorphoChainlinkOracleV2(
         IERC4626 baseVault,
         uint256 baseVaultConversionSample,

--- a/src/morpho-chainlink/interfaces/IMorphoChainlinkOracleV2Factory.sol
+++ b/src/morpho-chainlink/interfaces/IMorphoChainlinkOracleV2Factory.sol
@@ -22,6 +22,7 @@ interface IMorphoChainlinkOracleV2Factory {
     /// - Feeds are either Chainlink-compliant or the address zero.
     /// - Feeds have the same behavioral assumptions as Chainlink's.
     /// - The vaults, if set, are ERC4626-compliant.
+    /// - The feeds, if set, are Chainlink-interface-compliant.
     /// - Decimals passed as argument are correct.
     /// - The base vaults's sample shares quoted as assets and the base feed prices don't overflow when multiplied.
     /// - The quote vault's sample shares quoted as assets and the quote feed prices don't overflow when multiplied.
@@ -40,6 +41,7 @@ interface IMorphoChainlinkOracleV2Factory {
     /// @param quoteFeed2 Second quote feed. Pass address zero if the price = 1.
     /// @param quoteTokenDecimals Quote token decimals.
     /// @param salt The salt to use for the CREATE2.
+    /// @dev The base asset should be the collateral token and the quote asset the loan token.
     function createMorphoChainlinkOracleV2(
         IERC4626 baseVault,
         uint256 baseVaultConversionSample,

--- a/test/MorphoChainlinkOracleV2Test.sol
+++ b/test/MorphoChainlinkOracleV2Test.sol
@@ -99,9 +99,8 @@ contract MorphoChainlinkOracleV2Test is Test {
     }
 
     function testSDaiEthOracle() public {
-        MorphoChainlinkOracleV2 oracle = new MorphoChainlinkOracleV2(
-            sDaiVault, 1e18, daiEthFeed, feedZero, 18, vaultZero, 1, feedZero, feedZero, 18
-        );
+        MorphoChainlinkOracleV2 oracle =
+            new MorphoChainlinkOracleV2(sDaiVault, 1e18, daiEthFeed, feedZero, 18, vaultZero, 1, feedZero, feedZero, 18);
         (, int256 expectedPrice,,,) = daiEthFeed.latestRoundData();
         assertEq(
             oracle.price(),

--- a/test/MorphoChainlinkOracleV2Test.sol
+++ b/test/MorphoChainlinkOracleV2Test.sol
@@ -100,7 +100,7 @@ contract MorphoChainlinkOracleV2Test is Test {
 
     function testSDaiEthOracle() public {
         MorphoChainlinkOracleV2 oracle = new MorphoChainlinkOracleV2(
-            sDaiVault, 10 ** 18, daiEthFeed, feedZero, 18, vaultZero, 1, feedZero, feedZero, 18
+            sDaiVault, 1e18, daiEthFeed, feedZero, 18, vaultZero, 1, feedZero, feedZero, 18
         );
         (, int256 expectedPrice,,,) = daiEthFeed.latestRoundData();
         assertEq(
@@ -111,7 +111,7 @@ contract MorphoChainlinkOracleV2Test is Test {
 
     function testSDaiUsdcOracle() public {
         MorphoChainlinkOracleV2 oracle = new MorphoChainlinkOracleV2(
-            sDaiVault, 10 ** 18, daiEthFeed, feedZero, 18, vaultZero, 1, usdcEthFeed, feedZero, 6
+            sDaiVault, 1e18, daiEthFeed, feedZero, 18, vaultZero, 1, usdcEthFeed, feedZero, 6
         );
         (, int256 baseAnswer,,,) = daiEthFeed.latestRoundData();
         (, int256 quoteAnswer,,,) = usdcEthFeed.latestRoundData();


### PR DESCRIPTION
Fixes https://github.com/cantinasec/review-morpho/issues/12

> - [MorphoChainlinkOracleV2.sol#L128](https://github.com/morpho-org/morpho-blue-oracles/blob/af1a0d305071bbdcb38f1b7b128ba6d0c9f31684/src/morpho-chainlink/MorphoChainlinkOracleV2.sol#L128): "Chainlink" should be replaced with "Chainlink-compliant"

Completely removed "chainlink"

> - [IMorphoChainlinkOracleV2.sol#L25](https://github.com/morpho-org/morpho-blue-oracles/blob/af1a0d305071bbdcb38f1b7b128ba6d0c9f31684/src/morpho-chainlink/interfaces/IMorphoChainlinkOracleV2.sol#L25): These feeds are "chainlink-interface-compatible" but they could be feeds that are not from Chainlink itself. Consider to better clarify it.

I simply removed chainlink, as it doesn't add a lot here.

> - [IMorphoChainlinkOracleV2Factory.sol#L28](https://github.com/morpho-org/morpho-blue-oracles/blob/af1a0d305071bbdcb38f1b7b128ba6d0c9f31684/src/morpho-chainlink/interfaces/IMorphoChainlinkOracleV2Factory.sol#L28): the natspec comment should be re-written to use the "vault" term as plural

Actually there was a bigger problem, that I fixed. I also remove "feeds should be in the correct order" because usually these things are implied

> - [IMorphoChainlinkOracleV2Factory.sol#L43](https://github.com/morpho-org/morpho-blue-oracles/blob/af1a0d305071bbdcb38f1b7b128ba6d0c9f31684/src/morpho-chainlink/interfaces/IMorphoChainlinkOracleV2Factory.sol#L43): This factory does not create MM vaults but a MorphoChainlinkOracle. Replace "MetaMorpho vault" with "Morpho Chainlink oracle"

removed

> - [MorphoChainlinkOracleV2Test.sol#L103](https://github.com/morpho-org/morpho-blue-oracles/blob/af1a0d305071bbdcb38f1b7b128ba6d0c9f31684/test/MorphoChainlinkOracleV2Test.sol#L103) + [MorphoChainlinkOracleV2Test.sol#L114](https://github.com/morpho-org/morpho-blue-oracles/blob/af1a0d305071bbdcb38f1b7b128ba6d0c9f31684/test/MorphoChainlinkOracleV2Test.sol#L114): be consistent across all the tests (if there's not a specific reason to do otherwise). For the vast majority of instances you have used 1e18 but here and in testSDaiUsdcOracle you are using 10 ** 18

fixed