### PR TITLE
hardcode evm version to paris

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,6 +4,7 @@ out = "out"
 libs = ["lib"]
 optimizer_runs = 999999 # Etherscan does not support verifying contracts with more optimizer runs.
 via_ir = true
+evm_version = "paris"
 
 [profile.default.fmt]
 wrap_comments = true


### PR DESCRIPTION
Default evm version of foundry is paris (for the moment), let's hardcode it in case it changes.