### PR TITLE
Add capped LRT oracles for weETH and ezETH

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@morpho-org/morpho-blue-oracles",
+  "description": "Morpho Blue Oracles",
+  "license": "BUSL-1.1",
+  "version": "1.0.0",
+  "files": [
+    "src",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "lint:forge": "forge fmt --check",
+    "lint:fix": "yarn lint:forge:fix && yarn lint:hardhat:fix",
+    "lint:forge:fix": "forge fmt"
+  }
+}

--- a/src/exchange-rate-adapters/CappedRatioAdapter.sol
+++ b/src/exchange-rate-adapters/CappedRatioAdapter.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.19;
+
+import {ErrorsLib} from "./libraries/ErrorsLib.sol";
+
+/// @title CappedRatioAdapter
+/// @author Morpho Labs
+/// @custom:contact security@morpho.org
+/// @notice Abstract exchange rate price feed which caps the ratio to a max growth rate per year
+abstract contract CappedRatioAdapter {
+    /// @notice Ratio at the time of snapshot
+    uint104 private _snapshotRatio;
+
+    /// @notice Timestamp at the time of snapshot
+    uint48 private _snapshotTimestamp;
+
+    /// @notice Ratio growth per second
+    uint104 private _maxRatioGrowthPerSecond;
+
+    /// @notice Max yearly growth percent
+    uint256 public immutable MAX_YEARLY_RATIO_GROWTH_PERCENT;
+
+    /// @notice The minimum time which must pass before a new snapshot can be taken
+    uint256 public immutable MINIMUM_SNAPSHOT_GAP;
+
+    /// @notice Maximum percentage factor (100.00%)
+    uint256 public constant PERCENTAGE_FACTOR = 1e4;
+
+    /// @notice Number of seconds per year (365 days)
+    uint256 public constant SECONDS_PER_YEAR = 365 days;
+
+    /// @notice Minimal time while ratio should not overflow, in years
+    uint256 public constant MINIMAL_RATIO_INCREASE_LIFETIME_YRS = 10;
+
+    event SnapshotTaken(
+      uint256 snapshotRatio,
+      uint256 snapshotTimestamp,
+      uint256 maxRatioGrowthPerSecond
+    );
+
+    constructor(uint256 maxYearlyRatioGrowthPct, uint256 minSnapshotGap) {
+        MAX_YEARLY_RATIO_GROWTH_PERCENT = maxYearlyRatioGrowthPct;
+        MINIMUM_SNAPSHOT_GAP = minSnapshotGap;
+    }
+
+    /// @notice Permisionless for anyone to take a new snapshot
+    /// @dev The effect of calling this is to rebase the maxRatio() calculation from the ratio
+    /// as of now. It will revert if the current ratio is greater than the existing maxRatio()
+    /// Taking a new snapsho will effectively reduce the new `maxRatio()`, because the latest `getRatio()` 
+    /// will realistically be less now vs if we were to applying the previous max annual growth rate 
+    /// allowed on the old snapshot to now.
+    function takeSnapshot() public {
+        // A new snapshot can only be taken once every `MINIMUM_SNAPSHOT_GAP`
+        require(block.timestamp > _snapshotTimestamp + MINIMUM_SNAPSHOT_GAP, ErrorsLib.SNAPSHOT_TOO_SOON);
+
+        // Ensure the latest ratio is less than or equal to the previous max ratio.
+        uint256 ratio = getRatio();
+        uint256 maxRatio = getMaxRatio();
+        require(ratio > 0 && (maxRatio == 0 || ratio <= maxRatio), ErrorsLib.INVALID_SNAPSHOT_RATIO);
+
+        // The growth rate per second is rounded down, so effective growth rate
+        // may be a little under the MAX_YEARLY_RATIO_GROWTH_PERCENT
+        uint104 maxRatioGrowthPerSecond = uint104(
+            (ratio * MAX_YEARLY_RATIO_GROWTH_PERCENT)
+            / PERCENTAGE_FACTOR
+            / SECONDS_PER_YEAR
+        );
+
+        // Ensure the ratio on the current growth speed can't overflow in 
+        // less then MINIMAL_RATIO_INCREASE_LIFETIME_YRS years
+        require(
+            ratio + (maxRatioGrowthPerSecond * SECONDS_PER_YEAR * MINIMAL_RATIO_INCREASE_LIFETIME_YRS) < type(uint104).max,
+            ErrorsLib.SNAPSHOT_MAY_OVERFLOW_SOON
+        );
+        
+        emit SnapshotTaken(
+            ratio,
+            block.timestamp,
+            maxRatioGrowthPerSecond
+        );
+
+        _snapshotRatio = uint104(ratio);
+        _snapshotTimestamp = uint48(block.timestamp);
+        _maxRatioGrowthPerSecond = maxRatioGrowthPerSecond;
+    }
+
+    /// @dev Returns zero for roundId, startedAt, updatedAt and answeredInRound.
+    /// @dev Silently overflows if `amountForShare`'s return value is greater than `type(int256).max`.
+    function getCappedRatio() public view returns (uint256) {
+        uint256 currentRatio = getRatio();
+        uint256 maxRatio = getMaxRatio();
+
+        if (maxRatio < currentRatio) {
+            currentRatio = maxRatio;
+        }
+
+        return currentRatio;
+    }
+
+    /// @notice Whether the price is currently capped to the `MAX_YEARLY_RATIO_GROWTH_PERCENT`
+    function isCapped() public view returns (bool) {
+        uint256 currentRatio = getRatio();
+        uint256 maxRatio = getMaxRatio();
+        return currentRatio > maxRatio;
+    }
+    
+    /// @notice Returns the latest snapshot data
+    function getSnapshot() external view returns (uint256, uint256, uint256, uint256) {
+        return (
+            _snapshotRatio, 
+            _snapshotTimestamp, 
+            _maxRatioGrowthPerSecond, 
+            MAX_YEARLY_RATIO_GROWTH_PERCENT
+        );
+    }
+
+    /// @notice Returns the current exchange ratio of the LST/LRT to the underlying asset
+    function getRatio() public virtual view returns (uint256);
+
+    /// @notice Returns the maximum possible ratio allowed given the latest snapshot and a
+    /// max growth rate.
+    function getMaxRatio() public view returns (uint256) {
+        return uint256(_snapshotRatio) + _maxRatioGrowthPerSecond * (block.timestamp - _snapshotTimestamp);
+    }
+}

--- a/src/exchange-rate-adapters/EzEthToEthExchangeRateChainlinkAdapter.sol
+++ b/src/exchange-rate-adapters/EzEthToEthExchangeRateChainlinkAdapter.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.19;
+
+import {IRenzoRestakeManager} from "../interfaces/Renzo/IRenzoRestakeManager.sol";
+import {IRenzoOracle} from "../interfaces/Renzo/IRenzoOracle.sol";
+import {IERC20} from "../interfaces/IERC20.sol";
+import {MinimalAggregatorV3Interface} from "../wsteth-exchange-rate-adapter/interfaces/MinimalAggregatorV3Interface.sol";
+import {CappedRatioAdapter} from "./CappedRatioAdapter.sol";
+
+/// @title EzEthToEthExchangeRateChainlinkAdapter
+/// @author Morpho Labs
+/// @custom:contact security@morpho.org
+/// @notice ezETH/ETH exchange rate price feed.
+/// @dev This contract should only be deployed on Ethereum and used as a price feed for Morpho oracles.
+contract EzEthToEthExchangeRateChainlinkAdapter is CappedRatioAdapter, MinimalAggregatorV3Interface {
+    /// @inheritdoc MinimalAggregatorV3Interface
+    // @dev The calculated price has 18 decimals precision, whatever the value of `decimals`.
+    uint8 public override constant decimals = 18;
+
+    /// @notice The description of the price feed.
+    string public constant description = "ezETH/ETH exchange rate";
+
+    /// @notice The address of the Renzo restake manager in Ethereum.
+    IRenzoRestakeManager public constant RENZO_RESTAKE_MANAGER = IRenzoRestakeManager(0x74a09653A083691711cF8215a6ab074BB4e99ef5);
+
+    /// @notice The address of the Renzo ezETH token in Ethereum
+    IERC20 public constant EZ_ETH = IERC20(0xbf5495Efe5DB9ce00f80364C8B423567e58d2110);
+
+    constructor() CappedRatioAdapter(
+        875,   // maxYearlyRatioGrowthPct
+        7 days // minSnapshotGap
+    ) {
+        takeSnapshot();
+    }
+
+    /// @inheritdoc MinimalAggregatorV3Interface
+    /// @dev Returns zero for roundId, startedAt, updatedAt and answeredInRound.
+    /// @dev Silently overflows if `amountForShare`'s return value is greater than `type(int256).max`.
+    function latestRoundData() external override view returns (uint80, int256, uint256, uint256, uint80) {
+        return (0, int256(getCappedRatio()), 0, 0, 0);
+    }
+
+    /// @inheritdoc CappedRatioAdapter
+    function getRatio() public override view returns (uint256) {
+        (,, uint256 _currentValueInProtocol) = RENZO_RESTAKE_MANAGER.calculateTVLs();
+
+        // This is just returning the percentage of TVL that matches the percentage of ezETH being burned
+        // baseAsset is safely assumed to be the ezETH ERC20
+        uint256 totalSupply = EZ_ETH.totalSupply();
+        return IRenzoOracle(RENZO_RESTAKE_MANAGER.renzoOracle()).calculateRedeemAmount(
+            1 ether,
+            totalSupply,
+            _currentValueInProtocol
+        );
+    }
+}

--- a/src/exchange-rate-adapters/WeEthToEthExchangeRateChainlinkAdapter.sol
+++ b/src/exchange-rate-adapters/WeEthToEthExchangeRateChainlinkAdapter.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.19;
+
+import {IWeEth} from "../interfaces/etherfi/IWeEth.sol";
+import {MinimalAggregatorV3Interface} from "../wsteth-exchange-rate-adapter/interfaces/MinimalAggregatorV3Interface.sol";
+import {CappedRatioAdapter} from "./CappedRatioAdapter.sol";
+
+/// @title WeEthToEthExchangeRateChainlinkAdapter
+/// @author Morpho Labs
+/// @custom:contact security@morpho.org
+/// @notice weETH/ETH exchange rate price feed.
+/// @dev This contract should only be deployed on Ethereum and used as a price feed for Morpho oracles.
+contract WeEthToEthExchangeRateChainlinkAdapter is CappedRatioAdapter, MinimalAggregatorV3Interface {
+    /// @inheritdoc MinimalAggregatorV3Interface
+    // @dev The calculated price has 18 decimals precision, whatever the value of `decimals`.
+    uint8 public override constant decimals = 18;
+
+    /// @notice The description of the price feed.
+    string public constant description = "weETH/ETH exchange rate";
+
+    /// @notice The address of the weETH token on Ethereum.
+    IWeEth public constant WEETH = IWeEth(0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee);
+
+    constructor() CappedRatioAdapter(
+        875,   // maxYearlyRatioGrowthPct
+        7 days // minSnapshotGap
+    ) {
+        takeSnapshot();
+    }
+
+    /// @inheritdoc MinimalAggregatorV3Interface
+    /// @dev Returns zero for roundId, startedAt, updatedAt and answeredInRound.
+    /// @dev Silently overflows if `amountForShare`'s return value is greater than `type(int256).max`.
+    function latestRoundData() external override view returns (uint80, int256, uint256, uint256, uint80) {
+        return (0, int256(getCappedRatio()), 0, 0, 0);
+    }
+
+    /// @inheritdoc CappedRatioAdapter
+    function getRatio() public override view returns (uint256) {
+        // It is assumed that `getRate()` returns a price with 18 decimals precision.
+        return WEETH.getRate();
+    }
+}

--- a/src/exchange-rate-adapters/libraries/ErrorsLib.sol
+++ b/src/exchange-rate-adapters/libraries/ErrorsLib.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.19;
+
+/// @title ErrorsLib
+/// @author Morpho Labs
+/// @custom:contact security@morpho.org
+/// @notice Library exposing error messages.
+library ErrorsLib {
+    /// @notice Thrown when the weETH redemption price grows at a faster rate
+    /// than what is tolerable
+    string constant GROWTH_RATE_TOO_HIGH = "converstion rate growth too high";
+
+    string constant SNAPSHOT_TOO_SOON = "snapshot too soon";
+
+    string constant SNAPSHOT_MAY_OVERFLOW_SOON = "snapshot ratio may overflow soon";
+
+    string constant INVALID_SNAPSHOT_RATIO = "invalid snapshot ratio";
+}

--- a/src/interfaces/IERC20.sol
+++ b/src/interfaces/IERC20.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+interface IERC20 {
+    function totalSupply() external view returns (uint256);
+}

--- a/src/interfaces/etherfi/IWeEth.sol
+++ b/src/interfaces/etherfi/IWeEth.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+interface IWeEth {
+    // Amount of weETH for 1 eETH
+    function getRate() external view returns (uint256);
+}

--- a/src/interfaces/renzo/IRenzoOracle.sol
+++ b/src/interfaces/renzo/IRenzoOracle.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+interface IRenzoOracle {
+    function calculateRedeemAmount(
+        uint256 _ezETHBeingBurned,
+        uint256 _existingEzETHSupply,
+        uint256 _currentValueInProtocol
+    ) external pure returns (uint256);
+}

--- a/src/interfaces/renzo/IRenzoRestakeManager.sol
+++ b/src/interfaces/renzo/IRenzoRestakeManager.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+interface IRenzoRestakeManager {
+    function calculateTVLs() external view returns (uint256[][] memory, uint256[] memory, uint256);
+    function renzoOracle() external view returns (address);
+}

--- a/test/exchange-rate-adapters/CappedRatioAdapter.t.sol
+++ b/test/exchange-rate-adapters/CappedRatioAdapter.t.sol
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.19;
+
+import {Test} from "../../lib/forge-std/src/Test.sol";
+import {IWeEth} from "../../src/interfaces/etherfi/IWeEth.sol";
+import {CappedRatioAdapter} from "../../src/exchange-rate-adapters/CappedRatioAdapter.sol";
+
+contract MockWeEth is IWeEth {
+    function getRate() external pure returns (uint256) {
+        return 1.037312039562434994e18;
+    }
+}
+
+contract MockAdapter is CappedRatioAdapter {
+    IWeEth public immutable WEETH;
+
+    constructor(IWeEth _weeth) CappedRatioAdapter(
+        875,   // maxYearlyRatioGrowthPct
+        7 days // minSnapshotGap
+    ) {
+        WEETH = _weeth;
+        takeSnapshot();
+    }
+
+    /// @inheritdoc CappedRatioAdapter
+    function getRatio() public override view returns (uint256) {
+        // It is assumed that `getRate()` returns a price with 18 decimals precision.
+        return WEETH.getRate();
+    }
+}
+
+contract CappedRatioAdapterTest is Test {
+    MockAdapter internal adapter;
+
+    IWeEth internal WEETH;
+
+    event SnapshotTaken(
+      uint256 snapshotRatio,
+      uint256 snapshotTimestamp,
+      uint256 maxRatioGrowthPerSecond
+    );
+
+    function setUp() public {
+        vm.warp(1714000000);
+        WEETH = new MockWeEth();
+        adapter = new MockAdapter(WEETH);
+    }
+
+    function test_MAX_YEARLY_RATIO_GROWTH_PERCENT() public {
+        assertEq(adapter.MAX_YEARLY_RATIO_GROWTH_PERCENT(), 875);
+    }
+
+    function test_MINIMUM_SNAPSHOT_GAP() public {
+        assertEq(adapter.MINIMUM_SNAPSHOT_GAP(), 7 days);
+    }
+
+    function test_constants() public {
+        assertEq(adapter.PERCENTAGE_FACTOR(), 1e4);
+        assertEq(adapter.SECONDS_PER_YEAR(), 365 days);
+        assertEq(adapter.MINIMAL_RATIO_INCREASE_LIFETIME_YRS(), 10);
+    }
+
+    function test_getRatio() public {
+        assertEq(adapter.getRatio(), WEETH.getRate());
+    }
+
+    function test_getMaxRatio() public {
+        // At construction, the max ratio equals the latest snapshot
+        uint256 startRatio = adapter.getRatio();
+        assertEq(adapter.getMaxRatio(), startRatio);
+
+        skip(65 days);
+        assertEq(adapter.getMaxRatio(), 1.053475634698226994e18);
+
+        skip(300 days);
+        uint256 endRatio = adapter.getMaxRatio();
+        assertEq(endRatio, 1.128076843017266994e18);
+        uint256 growthRate = 100_000 * (endRatio - startRatio) / startRatio;
+        assertEq(growthRate, 8749);
+    }
+
+    function test_takeSnapshot_success_flatRatio() public {
+        // At construction, the max ratio equals the latest snapshot
+        (
+            uint256 sRatio, 
+            uint256 sTimestamp, 
+            uint256 maxRatioGrowthPerSec, 
+            uint256 maxRatioGrowthPerYr
+        ) = adapter.getSnapshot();
+
+        // At construction, the max ratio equals the latest snapshot
+        uint256 startRatio = adapter.getRatio();
+        assertEq(startRatio, 1.037312039562434994e18);
+        assertEq(sRatio, adapter.getRatio());
+        assertEq(sTimestamp, block.timestamp);
+        assertEq(maxRatioGrowthPerSec, 2878133037);
+        assertEq(maxRatioGrowthPerYr, 875);
+        assertEq(adapter.getMaxRatio(), startRatio);
+        
+        // Remains the same as time moves forward if no new snapshot
+        skip(365 days);
+        (
+            sRatio, 
+            sTimestamp, 
+            maxRatioGrowthPerSec, 
+            maxRatioGrowthPerYr
+        ) = adapter.getSnapshot();
+        assertEq(sRatio, startRatio);
+        assertEq(sTimestamp, block.timestamp - 365 days);
+        assertEq(maxRatioGrowthPerSec, 2878133037);
+        assertEq(maxRatioGrowthPerYr, 875);
+        assertEq(adapter.getMaxRatio(), 1.128076843017266994e18);
+
+        // Take a new snapshot. Since the assets & totalSupply in weETH is the same, the 
+        // maxRatioGrowthPerSec is the same
+        vm.expectEmit(address(adapter));
+        emit SnapshotTaken(startRatio, block.timestamp, 2878133037);
+        adapter.takeSnapshot();
+        (
+            sRatio, 
+            sTimestamp, 
+            maxRatioGrowthPerSec, 
+            maxRatioGrowthPerYr
+        ) = adapter.getSnapshot();
+        assertEq(sRatio, startRatio);
+        assertEq(sTimestamp, block.timestamp);
+        assertEq(maxRatioGrowthPerSec, 2878133037);
+        assertEq(maxRatioGrowthPerYr, 875);
+        assertEq(adapter.getMaxRatio(), startRatio);
+    }
+
+    function test_takeSnapshot_success_increasingRatio() public {
+        // At construction, the max ratio equals the latest snapshot
+        (
+            uint256 sRatio, 
+            uint256 sTimestamp, 
+            uint256 maxRatioGrowthPerSec, 
+            uint256 maxRatioGrowthPerYr
+        ) = adapter.getSnapshot();
+
+        // At construction, the max ratio equals the latest snapshot
+        uint256 startRatio = adapter.getRatio();
+        assertEq(startRatio, 1.037312039562434994e18);
+        assertEq(sRatio, adapter.getRatio());
+        assertEq(sTimestamp, block.timestamp);
+        assertEq(maxRatioGrowthPerSec, 2878133037);
+        assertEq(maxRatioGrowthPerYr, 875);
+        assertEq(adapter.getMaxRatio(), startRatio);
+
+        // Set the rate higher but less than the max
+        uint256 mockRate = 1.1e18;
+        vm.mockCall(
+            address(WEETH),
+            abi.encodeWithSelector(IWeEth.getRate.selector),
+            abi.encode(mockRate)
+        );
+
+        // Remains the same as time moves forward if no new snapshot
+        skip(365 days);
+        (
+            sRatio, 
+            sTimestamp, 
+            maxRatioGrowthPerSec, 
+            maxRatioGrowthPerYr
+        ) = adapter.getSnapshot();
+        assertEq(sRatio, startRatio);
+        assertEq(sTimestamp, block.timestamp - 365 days);
+        assertEq(maxRatioGrowthPerSec, 2878133037);
+        assertEq(maxRatioGrowthPerYr, 875);
+        assertEq(adapter.getRatio(), mockRate);
+        assertEq(adapter.getMaxRatio(), 1.128076843017266994e18);
+
+        // Take a new snapshot. Since the assets & totalSupply in weETH is the same, the 
+        // maxRatioGrowthPerSec is the same
+        adapter.takeSnapshot();
+        (
+            sRatio, 
+            sTimestamp, 
+            maxRatioGrowthPerSec, 
+            maxRatioGrowthPerYr
+        ) = adapter.getSnapshot();
+        assertEq(sRatio, mockRate);
+        assertEq(sTimestamp, block.timestamp);
+        assertEq(maxRatioGrowthPerSec, 3052067478);
+        assertEq(maxRatioGrowthPerYr, 875);
+        assertEq(adapter.getRatio(), mockRate);
+        assertEq(adapter.getMaxRatio(), mockRate);
+
+        skip(365 days);
+        assertEq(adapter.getMaxRatio(), 1.196249999986208000e18);
+    }
+
+    function test_takeSnapshot_success_decreasingRatio() public {
+        // At construction, the max ratio equals the latest snapshot
+        (
+            uint256 sRatio, 
+            uint256 sTimestamp, 
+            uint256 maxRatioGrowthPerSec, 
+            uint256 maxRatioGrowthPerYr
+        ) = adapter.getSnapshot();
+
+        // At construction, the max ratio equals the latest snapshot
+        uint256 startRatio = adapter.getRatio();
+        assertEq(startRatio, 1.037312039562434994e18);
+        assertEq(sRatio, adapter.getRatio());
+        assertEq(sTimestamp, block.timestamp);
+        assertEq(maxRatioGrowthPerSec, 2878133037);
+        assertEq(maxRatioGrowthPerYr, 875);
+        assertEq(adapter.getMaxRatio(), startRatio);
+
+        // Set the rate higher but less than the max
+        uint256 mockRate = 1.01e18;
+        vm.mockCall(
+            address(WEETH),
+            abi.encodeWithSelector(IWeEth.getRate.selector),
+            abi.encode(mockRate)
+        );
+
+        // Remains the same as time moves forward if no new snapshot
+        skip(365 days);
+        (
+            sRatio, 
+            sTimestamp, 
+            maxRatioGrowthPerSec, 
+            maxRatioGrowthPerYr
+        ) = adapter.getSnapshot();
+        assertEq(sRatio, startRatio);
+        assertEq(sTimestamp, block.timestamp - 365 days);
+        assertEq(maxRatioGrowthPerSec, 2878133037);
+        assertEq(maxRatioGrowthPerYr, 875);
+        assertEq(adapter.getRatio(), mockRate);
+        assertEq(adapter.getMaxRatio(), 1.128076843017266994e18);
+
+        // Take a new snapshot. Since the assets & totalSupply in weETH is the same, the 
+        // maxRatioGrowthPerSec is the same
+        adapter.takeSnapshot();
+        (
+            sRatio, 
+            sTimestamp, 
+            maxRatioGrowthPerSec, 
+            maxRatioGrowthPerYr
+        ) = adapter.getSnapshot();
+        assertEq(sRatio, mockRate);
+        assertEq(sTimestamp, block.timestamp);
+        assertEq(maxRatioGrowthPerSec, 2802352866);
+        assertEq(maxRatioGrowthPerYr, 875);
+        assertEq(adapter.getRatio(), mockRate);
+        assertEq(adapter.getMaxRatio(), mockRate);
+
+        skip(365 days);
+        assertEq(adapter.getMaxRatio(), 1.098374999982176000e18);
+    }
+
+    function test_takeSnapshot_fail_tooSoon() public {
+        vm.expectRevert("snapshot too soon");
+        adapter.takeSnapshot();
+
+        skip(adapter.MINIMUM_SNAPSHOT_GAP()+1);
+        adapter.takeSnapshot();
+    }
+
+    function test_takeSnapshot_fail_zeroRatio() public {
+        skip(10 days);
+        vm.mockCall(
+            address(WEETH),
+            abi.encodeWithSelector(IWeEth.getRate.selector),
+            abi.encode(0)
+        );
+
+        vm.expectRevert("invalid snapshot ratio");
+        adapter.takeSnapshot();
+    }
+
+    function test_takeSnapshot_fail_ratioTooHigh() public {
+        skip(10 days);
+        vm.mockCall(
+            address(WEETH),
+            abi.encodeWithSelector(IWeEth.getRate.selector),
+            abi.encode(1.3e18)
+        );
+
+        vm.expectRevert("invalid snapshot ratio");
+        adapter.takeSnapshot();
+    }
+
+    function test_takeSnapshot_fail_growthRate() public {
+        uint256 mockRate = type(uint104).max - 100e18;
+        vm.mockCall(
+            address(WEETH),
+            abi.encodeWithSelector(IWeEth.getRate.selector),
+            abi.encode(mockRate)
+        );
+        vm.expectRevert("snapshot ratio may overflow soon");
+        adapter = new MockAdapter(WEETH);
+    }
+
+    function test_getCappedRatio_under() public {
+        skip(365 days);
+        uint256 mockRate = 1.05e18;
+        vm.mockCall(
+            address(WEETH),
+            abi.encodeWithSelector(IWeEth.getRate.selector),
+            abi.encode(mockRate)
+        );
+        assertEq(adapter.getMaxRatio(), 1.128076843017266994e18);
+        assertEq(adapter.isCapped(), false);
+        assertEq(adapter.getCappedRatio(), mockRate);
+    }
+
+    function test_getCappedRatio_over() public {
+        skip(365 days);
+        uint256 mockRate = 1.3e18;
+        vm.mockCall(
+            address(WEETH),
+            abi.encodeWithSelector(IWeEth.getRate.selector),
+            abi.encode(mockRate)
+        );
+        assertEq(adapter.getMaxRatio(), 1.128076843017266994e18);
+        assertEq(adapter.isCapped(), true);
+        assertEq(adapter.getCappedRatio(), 1.128076843017266994e18);
+    }
+}

--- a/test/exchange-rate-adapters/EzEthToEthExchangeRateChainlinkAdapterTest.sol
+++ b/test/exchange-rate-adapters/EzEthToEthExchangeRateChainlinkAdapterTest.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.19;
+
+import {vaultZero, feedZero} from "../helpers/Constants.sol";
+import {Test} from "../../lib/forge-std/src/Test.sol";
+import {MorphoChainlinkOracleV2} from "../../src/morpho-chainlink/MorphoChainlinkOracleV2.sol";
+import {EzEthToEthExchangeRateChainlinkAdapter} from "../../src/exchange-rate-adapters/EzEthToEthExchangeRateChainlinkAdapter.sol";
+import {IRenzoRestakeManager} from "../../src/interfaces/Renzo/IRenzoRestakeManager.sol";
+import {IRenzoOracle} from "../../src/interfaces/Renzo/IRenzoOracle.sol";
+import {IERC20} from "../../src/interfaces/IERC20.sol";
+import {AggregatorV3Interface} from "../../src/morpho-chainlink/interfaces/AggregatorV3Interface.sol";
+
+contract EzEthToEthExchangeRateChainlinkAdapterTest is Test {
+    IRenzoRestakeManager public constant RENZO_RESTAKE_MANAGER = IRenzoRestakeManager(0x74a09653A083691711cF8215a6ab074BB4e99ef5);
+    IERC20 public constant EZ_ETH = IERC20(0xbf5495Efe5DB9ce00f80364C8B423567e58d2110);
+
+    EzEthToEthExchangeRateChainlinkAdapter internal adapter;
+    MorphoChainlinkOracleV2 internal morphoOracle;
+
+    function setUp() public {
+        vm.createSelectFork(vm.envString("ETH_RPC_URL"), 19767680);
+        require(block.chainid == 1, "chain isn't Ethereum");
+        adapter = new EzEthToEthExchangeRateChainlinkAdapter();
+        morphoOracle = new MorphoChainlinkOracleV2(
+            vaultZero, 1, AggregatorV3Interface(address(adapter)), feedZero, 18, vaultZero, 1, feedZero, feedZero, 18
+        );
+    }
+
+    function test_decimals() public {
+        assertEq(adapter.decimals(), uint8(18));
+    }
+
+    function test_description() public {
+        assertEq(adapter.description(), "ezETH/ETH exchange rate");
+    }
+
+    function test_getRatio() public {
+        uint256 ratio = adapter.getRatio();
+
+        uint256 expectedRatio;
+        {
+            (,, uint256 _currentValueInProtocol) = RENZO_RESTAKE_MANAGER.calculateTVLs();
+            uint256 totalSupply = EZ_ETH.totalSupply();
+            expectedRatio = IRenzoOracle(RENZO_RESTAKE_MANAGER.renzoOracle()).calculateRedeemAmount(
+                1 ether,
+                totalSupply,
+                _currentValueInProtocol
+            );
+        }
+
+        assertEq(ratio, expectedRatio);
+        assertEq(ratio, 1.008385750262871563e18);  // Exchange rate queried at block 19767680
+    }
+
+    function test_latestRoundData() public {
+        (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) =
+            adapter.latestRoundData();
+        assertEq(roundId, 0);
+        assertEq(uint256(answer), adapter.getRatio());
+        assertEq(startedAt, 0);
+        assertEq(updatedAt, 0);
+        assertEq(answeredInRound, 0);
+    }
+
+    function test_oracleWeEthToEthExchangeRate() public {
+        (, int256 expectedPrice,,,) = adapter.latestRoundData();
+        assertEq(morphoOracle.price(), uint256(expectedPrice) * 10 ** (36 + 18 - 18 - 18));
+    }
+}

--- a/test/exchange-rate-adapters/WeEthToEthExchangeRateChainlinkAdapterTest.sol
+++ b/test/exchange-rate-adapters/WeEthToEthExchangeRateChainlinkAdapterTest.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.19;
+
+import {vaultZero, feedZero} from "../helpers/Constants.sol";
+import {Test} from "../../lib/forge-std/src/Test.sol";
+import {MorphoChainlinkOracleV2} from "../../src/morpho-chainlink/MorphoChainlinkOracleV2.sol";
+import {WeEthToEthExchangeRateChainlinkAdapter} from "../../src/exchange-rate-adapters/WeEthToEthExchangeRateChainlinkAdapter.sol";
+import {AggregatorV3Interface} from "../../src/morpho-chainlink/interfaces/AggregatorV3Interface.sol";
+import {IWeEth} from "../../src/interfaces/etherfi/IWeEth.sol";
+
+contract WeEthToEthExchangeRateChainlinkAdapterTest is Test {
+    IWeEth public constant WEETH = IWeEth(0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee);
+
+    WeEthToEthExchangeRateChainlinkAdapter internal adapter;
+    MorphoChainlinkOracleV2 internal morphoOracle;
+
+    function setUp() public {
+        vm.createSelectFork(vm.envString("ETH_RPC_URL"), 19767680);
+        require(block.chainid == 1, "chain isn't Ethereum");
+        adapter = new WeEthToEthExchangeRateChainlinkAdapter();
+        morphoOracle = new MorphoChainlinkOracleV2(
+            vaultZero, 1, AggregatorV3Interface(address(adapter)), feedZero, 18, vaultZero, 1, feedZero, feedZero, 18
+        );
+    }
+
+    function test_decimals() public {
+        assertEq(adapter.decimals(), uint8(18));
+    }
+
+    function test_description() public {
+        assertEq(adapter.description(), "weETH/ETH exchange rate");
+    }
+
+    function test_getRatio() public {
+        uint256 ratio = adapter.getRatio();
+        assertEq(ratio, WEETH.getRate());
+        assertEq(ratio, 1.037312039562434994e18);  // Exchange rate queried at block 19767680
+    }
+
+    function test_latestRoundData() public {
+        (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) =
+            adapter.latestRoundData();
+        assertEq(roundId, 0);
+        assertEq(uint256(answer), adapter.getRatio());
+        assertEq(startedAt, 0);
+        assertEq(updatedAt, 0);
+        assertEq(answeredInRound, 0);
+    }
+
+    function test_oracleWeEthToEthExchangeRate() public {
+        (, int256 expectedPrice,,,) = adapter.latestRoundData();
+        assertEq(morphoOracle.price(), uint256(expectedPrice) * 10 ** (36 + 18 - 18 - 18));
+    }
+}


### PR DESCRIPTION
The existing ether.fi and Renzo markets rely on Redstone oracles to price in terms of ETH:
- [weETH / WETH 86%](https://risk.morpho.org/market?id=0x698fe98247a40c5771537b5786b2f3f9d78eb487b4ce4d75533cd0e94d88a115)
- [ezETH / WETH 86%](https://risk.morpho.org/market?id=0x49bb2d114be9041a787432952927f6f144f05ad3e83196a7d062f374ee11d0ee)

However if (and only if) redemptions in the LRT/LST are open, then it is preferred to utilise the onchain redemption price rather than depend on a chainlink/redstone oracle aggregator. This is because any temporary liquidity issues or quick large sells into low liquidity AMMs can cause a move in the off-chain oracle, which introduces an unnecessary risk of liquidations.

This was seen recently within [ezETH](https://risk.morpho.org/market?id=0x49bb2d114be9041a787432952927f6f144f05ad3e83196a7d062f374ee11d0ee), where a large amount of positions were liquidated. Redemptions are NOT open there (but will be shortly).

Both weETH and ezETH are upgradeable contracts, and so to add security against manipulation of this share price, a cap is added to the maximum expected growth rate. If the share price is larger than this cap then the capped amount is returned.

This follows a similar Oracle structure to the existing (and very popular) [Aave v3 weETH market](https://app.aave.com/reserve-overview/?underlyingAsset=0x35751007a407ca6feffe80b3cb397736d2cf4dbe&marketName=proto_arbitrum_v3). The Aave oracle for this market is [here](https://vscode.blockscan.com/ethereum/0xf112aF6F0A332B815fbEf3Ff932c057E570b62d3)

Because of the reduction in liquidation risk, the LLTV of these pools could also be increased.

This also follows suit with the existing Morpho wstETH markets, where two exist for the same LLTV:
- [Chainlink Oracle](https://risk.morpho.org/market?id=0xd0e50cdac92fe2172043f5e0c36532c6369d24947e40968f34a5e8819ca9ec5d)
- [Onchain wstETH redemption price](https://risk.morpho.org/market?id=0xd0e50cdac92fe2172043f5e0c36532c6369d24947e40968f34a5e8819ca9ec5d)

The latter market is far preferred from a borrower's perspective. Ideally the metamorpho vaults direct most of the liquidity to that latter pool, sooner rather than later.

Further reading on Spark's forum's pegging stETH/ETH to 1:1 is a worthwhile read, which also applies to the other LRTs
- https://verdant-fennel-aac.notion.site/Analysis-of-market-price-vs-exchange-rate-for-wstETH-5cc37780a66a474fbd5734d655e413c9
- https://forum.makerdao.com/t/spark-spell-proposed-changes/23298#ethereum-update-the-wsteth-oracle-to-assume-a-11-stetheth-peg-5
