### PR TITLE
Add SfrxETH-FrxETH exchange rate adapter

### DIFF
--- a/src/sfrxeth-exchange-rate-adapter/SfrxEthFrxEthExchangeRateChainlinkAdapter.sol
+++ b/src/sfrxeth-exchange-rate-adapter/SfrxEthFrxEthExchangeRateChainlinkAdapter.sol
@@ -23,7 +23,7 @@ contract SfrxEthFrxEthExchangeRateChainlinkAdapter is
 
     /// @inheritdoc MinimalAggregatorV3Interface
     /// @dev Returns zero for roundId, startedAt, updatedAt and answeredInRound.
-    /// @dev Silently overflows if `getPooledEthByShares`'s return value is greater than `type(int256).max`.
+    /// @dev Silently overflows if `pricePerShare`'s return value is greater than `type(int256).max`.
     function latestRoundData()
         external
         view

--- a/src/sfrxeth-exchange-rate-adapter/SfrxEthFrxEthExchangeRateChainlinkAdapter.sol
+++ b/src/sfrxeth-exchange-rate-adapter/SfrxEthFrxEthExchangeRateChainlinkAdapter.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.21;
+
+import {ISfrxEth} from "./interfaces/ISfrxEth.sol";
+import {MinimalAggregatorV3Interface} from "../wsteth-exchange-rate-adapter/interfaces/MinimalAggregatorV3Interface.sol";
+
+/// @title SfrxEthFrxEthExchangeRateChainlinkAdapter
+/// @notice sfrxETH/frxETH exchange rate price feed
+/// @dev The contract should only be deployed on Ethereum and used as a price feed for Morpho oracles.
+contract SfrxEthFrxEthExchangeRateChainlinkAdapter is
+    MinimalAggregatorV3Interface
+{
+    /// @notice inheritdoc MinimalAggregatorV3Interface
+    /// @dev The calculated price has 18 decimals precision.
+    uint8 public constant decimals = 18;
+
+    /// @notice The description of the price feed.
+    string public constant description = "sfrxETH/frxETH exchange rate";
+
+    /// @notice The address of sfrxETH on Ethereum.
+    ISfrxEth public constant SFRX_ETH =
+        ISfrxEth(0xac3E018457B222d93114458476f3E3416Abbe38F);
+
+    /// @inheritdoc MinimalAggregatorV3Interface
+    /// @dev Returns zero for roundId, startedAt, updatedAt and answeredInRound.
+    /// @dev Silently overflows if `getPooledEthByShares`'s return value is greater than `type(int256).max`.
+    function latestRoundData()
+        external
+        view
+        returns (uint80, int256, uint256, uint256, uint80)
+    {
+        // It is assumed that `pricePerShare` returns a price with 18 decimals precision.
+        return (0, int256(SFRX_ETH.pricePerShare()), 0, 0, 0);
+    }
+}

--- a/src/sfrxeth-exchange-rate-adapter/interfaces/ISfrxEth.sol
+++ b/src/sfrxeth-exchange-rate-adapter/interfaces/ISfrxEth.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+interface ISfrxEth {
+    function pricePerShare() external view returns (uint256);
+}

--- a/test/SfrxEthFrxEthExchangeRateChainlinkAdapterTest.sol
+++ b/test/SfrxEthFrxEthExchangeRateChainlinkAdapterTest.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import "./helpers/Constants.sol";
+import "../lib/forge-std/src/Test.sol";
+import {MorphoChainlinkOracleV2} from "../src/morpho-chainlink/MorphoChainlinkOracleV2.sol";
+import "../src/sfrxeth-exchange-rate-adapter/SfrxEthFrxEthExchangeRateChainlinkAdapter.sol";
+import "../src/sfrxeth-exchange-rate-adapter/interfaces/ISfrxEth.sol";
+
+contract SfrxEthFrxEthExchangeRateChainlinkAdapterTest is Test {
+    ISfrxEth internal constant SFRX_ETH =
+        ISfrxEth(0xac3E018457B222d93114458476f3E3416Abbe38F);
+
+    SfrxEthFrxEthExchangeRateChainlinkAdapter internal adapter;
+    MorphoChainlinkOracleV2 internal morphoOracle;
+
+    function setUp() public {
+        vm.createSelectFork(vm.envString("ETH_RPC_URL"));
+        require(block.chainid == 1, "chain isn't Ethereum");
+        adapter = new SfrxEthFrxEthExchangeRateChainlinkAdapter();
+        morphoOracle = new MorphoChainlinkOracleV2(
+            vaultZero,
+            1,
+            AggregatorV3Interface(address(adapter)),
+            feedZero,
+            18,
+            vaultZero,
+            1,
+            feedZero,
+            feedZero,
+            18
+        );
+    }
+
+    function testDecimals() public {
+        assertEq(adapter.decimals(), uint8(18));
+    }
+
+    function testDescription() public {
+        assertEq(adapter.description(), "sfrxETH/frxETH exchange rate");
+    }
+
+    function testLatestRoundData() public {
+        (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        ) = adapter.latestRoundData();
+        assertEq(roundId, 0);
+        assertEq(uint256(answer), SFRX_ETH.pricePerShare());
+        assertEq(startedAt, 0);
+        assertEq(updatedAt, 0);
+        assertEq(answeredInRound, 0);
+    }
+
+    function testLatestRoundDataBounds() public {
+        (, int256 answer, , , ) = adapter.latestRoundData();
+        assertGe(uint256(answer), 1087522005449750632); // Exchange rate queried at block 19966877
+        assertLe(uint256(answer), 1.5e18); // Max bounds of the exchange rate. Should work for a long enough time.
+    }
+
+    function testOracleSfrxEthFrxEthExchangeRate() public {
+        (, int256 expectedPrice, , , ) = adapter.latestRoundData();
+        assertEq(
+            morphoOracle.price(),
+            uint256(expectedPrice) * 10 ** (36 + 18 - 18 - 18)
+        );
+    }
+}


### PR DESCRIPTION
This PR creates an sfrxETH-frxETH exchange rate adapter following the structure of the wstETH-stETH exchange rate adapter. The only difference is that the exchange rate is computed by calling the [pricePerShare](https://etherscan.io/address/0xac3e018457b222d93114458476f3e3416abbe38f#readContract#F20) function instead of `getPooledEthByShares`.

Run tests via: 
```
forge test --match-path test/SfrxEthFrxEthExchangeRateChainlinkAdapterTest.sol
```
![image](https://github.com/morpho-org/morpho-blue-oracles/assets/1022632/9440a3cd-c4ba-4a50-82c0-8fd9afbe44b9)
